### PR TITLE
[feature/cart] 장바구니 도메인 설계

### DIFF
--- a/src/main/java/com/gorogoro_cart/cart/domain/model/entity/Cart.java
+++ b/src/main/java/com/gorogoro_cart/cart/domain/model/entity/Cart.java
@@ -1,0 +1,24 @@
+package com.gorogoro_cart.cart.domain.model.entity;
+
+import com.gorogoro_cart.cart.domain.model.vo.CartItem;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.List;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Cart {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    private List<CartItem> cartItems;
+}

--- a/src/main/java/com/gorogoro_cart/cart/domain/model/entity/Cart.java
+++ b/src/main/java/com/gorogoro_cart/cart/domain/model/entity/Cart.java
@@ -1,24 +1,21 @@
 package com.gorogoro_cart.cart.domain.model.entity;
 
 import com.gorogoro_cart.cart.domain.model.vo.CartItem;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import java.util.ArrayList;
 import java.util.List;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
-@Entity
-@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@Getter
 public class Cart {
+    private final Long id;
+    private final Long userId;
+    private final List<CartItem> cartItems = new ArrayList<>();
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
-    @Column(nullable = false, unique = true)
-    private Long userId;
-
-    private List<CartItem> cartItems;
+    private Cart(Long id, Long userId, List<CartItem> cartItems) {
+        this.id = id;
+        this.userId = userId;
+        if (cartItems != null) {
+            this.cartItems.addAll(cartItems);
+        }
+    }
 }

--- a/src/main/java/com/gorogoro_cart/cart/domain/model/vo/CartItem.java
+++ b/src/main/java/com/gorogoro_cart/cart/domain/model/vo/CartItem.java
@@ -1,0 +1,9 @@
+package com.gorogoro_cart.cart.domain.model.vo;
+
+import java.time.LocalDateTime;
+
+public record CartItem(
+        Long courseId,
+        LocalDateTime addedAt
+) {
+}

--- a/src/main/java/com/gorogoro_cart/cart/infrastructure/persistence/entity/CartItemJpaEntity.java
+++ b/src/main/java/com/gorogoro_cart/cart/infrastructure/persistence/entity/CartItemJpaEntity.java
@@ -1,0 +1,38 @@
+package com.gorogoro_cart.cart.infrastructure.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "cart_item",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_cart_item_user_course",
+                        columnNames = {"user_id", "course_id"})
+        })
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CartItemJpaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private Long courseId;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime addedAt;
+}


### PR DESCRIPTION
## Issue
- #1 

## 변경 사항
- 기존에는 Cart–CartItem JPA 연관관계를 기준으로 설계되어 Cart가 사실상 CartItem을 위한 매핑 엔티티 역할에 머물러 있었습니다.
- Cart를 “사용자의 장바구니” 애그리게잇 루트로, CartItem을 구성 요소로 두는 도메인 모델을 먼저 정의하고,
영속성 계층에서는 userId + courseId를 키로 가지는 CartItem JPA 엔티티 하나로만 저장하도록 분리했습니다. (cart_item 단일 테이블 기반)