### PR TITLE
userId와 courseId null validation 추가

### DIFF
--- a/src/main/java/com/gorogoro_cart/cart/application/port/in/command/AddCourseToCartCommand.java
+++ b/src/main/java/com/gorogoro_cart/cart/application/port/in/command/AddCourseToCartCommand.java
@@ -1,7 +1,9 @@
 package com.gorogoro_cart.cart.application.port.in.command;
 
+import jakarta.validation.constraints.NotNull;
+
 public record AddCourseToCartCommand(
-        Long userId,
-        Long courseId
+        @NotNull Long userId,
+        @NotNull Long courseId
 ) {
 }

--- a/src/main/java/com/gorogoro_cart/cart/application/port/in/event/CourseStatusChangedEvent.java
+++ b/src/main/java/com/gorogoro_cart/cart/application/port/in/event/CourseStatusChangedEvent.java
@@ -1,7 +1,9 @@
 package com.gorogoro_cart.cart.application.port.in.event;
 
+import jakarta.validation.constraints.NotNull;
+
 public record CourseStatusChangedEvent(
-        Long courseId,
+        @NotNull Long courseId,
         String newStatus
 ) {
 }


### PR DESCRIPTION
## 변경 사항

> not null 이어야 하는 id 값의 경우 원시 타입 long 형으로 두는 방식은 어떻게 생각하시나요? nullable 하게 열어두었을 때 이점이 무엇이 있을 지 잘 모르겠습니다.

이전 리뷰에서 long 타입 고려 의견을 받아, 이번 변경의 맥락에서 어떤 선택이 더 적절한지 정리해 보았습니다.

### long도 고려했지만 Long을 선택한 이유

이번 Command는 Controller에서 JSON 요청을 바인딩해 전달받는 입력 모델의 성격이 강하다고 생각했습니다.
이 경우 Long을 사용하면 값 누락 상태를 명확히 표현하고 검증으로 조기에 차단할 수 있다는 점이 장점이 있습니다.

- Long의 null은 “ID 값이 아직 할당되지 않았음” 또는 “클라이언트가 ID 값을 보내지 않았음”이라는 상태를 자연스럽게 표현합니다.
- long은 null이 될 수 없어 요청에서 필드가 누락되면 기본값 0이 들어갈 수 있습니다. 이 값은 유효한 숫자처럼 보이기 때문에 서비스 로직이 의도치 않게 진행될 가능성이 있습니다.

만약, 클라이언트가 실수로 JSON 요청에서 courseId 필드를 누락한 경우 `AddCourseToCartCommand(Long courseId)`는 null이 되어
`@NotNull` 등 검증을 통해 조기에 문제를 발견할 수 있습니다.
하지만, long으로 받을 경우 0이 들어가 서비스가 유효한 입력처럼 인식하고 id=0을 조회하려는 흐름이 생길 수 있어 원인 파악이 어려운 버그로 이어질 수 있다고 판단했습니다.

그리고 엔티티의 식별자가 Long인 점을 기준으로 Port도 Long으로 유지하여 레이어 간 타입 혼용으로 인한 인지 비용과 변환 부담을 줄이고자 모델과 경계 간 타입 일관성을 맞추는 방향을 선택했습니다.

### 추가로 고려할 수 있는 방향

long과 Long의 선택 기준을 더 명확히 하고 논쟁 여지를 줄이기 위해 `CourseId` 같은 식별자 타입을 도입해 불변식을 타입 레벨에서 강제하는 방법도 대안이 될 수 있다고 합니다.