### PR TITLE
[Feature/cart-all-clear] 장바구니 전체 비우기 기능 구현

### DIFF
--- a/src/main/java/com/gorogoro_cart/cart/application/port/in/ClearCartUseCase.java
+++ b/src/main/java/com/gorogoro_cart/cart/application/port/in/ClearCartUseCase.java
@@ -3,5 +3,5 @@ package com.gorogoro_cart.cart.application.port.in;
 import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
 
 public interface ClearCartUseCase {
-    void clearCart(ClearCartCommand command);
+    void clearCart(ClearCartCommand clearCartCommand);
 }

--- a/src/main/java/com/gorogoro_cart/cart/application/port/in/ClearCartUseCase.java
+++ b/src/main/java/com/gorogoro_cart/cart/application/port/in/ClearCartUseCase.java
@@ -1,0 +1,7 @@
+package com.gorogoro_cart.cart.application.port.in;
+
+import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
+
+public interface ClearCartUseCase {
+    void clearCart(ClearCartCommand command);
+}

--- a/src/main/java/com/gorogoro_cart/cart/application/port/in/command/ClearCartCommand.java
+++ b/src/main/java/com/gorogoro_cart/cart/application/port/in/command/ClearCartCommand.java
@@ -1,0 +1,8 @@
+package com.gorogoro_cart.cart.application.port.in.command;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ClearCartCommand(
+        @NotNull Long userId
+) {
+}

--- a/src/main/java/com/gorogoro_cart/cart/application/service/CartCommandService.java
+++ b/src/main/java/com/gorogoro_cart/cart/application/service/CartCommandService.java
@@ -5,7 +5,9 @@ import com.gorogoro_cart.cart.application.port.in.ClearCartUseCase;
 import com.gorogoro_cart.cart.application.port.in.command.AddCourseToCartCommand;
 import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
 import com.gorogoro_cart.cart.domain.model.entity.Cart;
+import com.gorogoro_cart.cart.domain.model.vo.CartItem;
 import com.gorogoro_cart.cart.domain.repository.CartRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,20 +20,36 @@ public class CartCommandService implements AddCourseToCartUseCase, ClearCartUseC
 
     @Override
     public void addCourse(AddCourseToCartCommand command) {
-        Cart cart = getCart(command.userId());
-        cart.addCourse(command.courseId());
-        cartRepository.save(cart);
+        Long userId = command.userId();
+
+        List<CartItem> baselineItems = loadBaselineItems(userId);
+        Cart targetCart = buildTargetCart(userId, baselineItems);
+        targetCart.addCourse(command.courseId());
+
+        cartRepository.save(targetCart, baselineItems);
     }
 
     @Override
     public void clearCart(ClearCartCommand command) {
-        Cart cart = getCart(command.userId());
-        cart.clear();
-        cartRepository.save(cart);
+        Long userId = command.userId();
+
+        List<CartItem> baselineItems = loadBaselineItems(userId);
+        Cart targetCart = buildTargetCart(userId, baselineItems);
+        targetCart.clear();
+
+        cartRepository.save(targetCart, baselineItems);
     }
 
-    private Cart getCart(Long userId) {
+    private List<CartItem> loadBaselineItems(Long userId) {
         return cartRepository.findAllByUserId(userId)
-                .orElseGet(() -> Cart.create(userId));
+                .map(Cart::getItems)
+                .orElseGet(List::of);
+    }
+
+    private Cart buildTargetCart(Long userId, List<CartItem> baselineItems) {
+        if (baselineItems.isEmpty()) {
+            return Cart.create(userId);
+        }
+        return Cart.create(userId, baselineItems);
     }
 }

--- a/src/main/java/com/gorogoro_cart/cart/application/service/CartCommandService.java
+++ b/src/main/java/com/gorogoro_cart/cart/application/service/CartCommandService.java
@@ -1,7 +1,11 @@
 package com.gorogoro_cart.cart.application.service;
 
 import com.gorogoro_cart.cart.application.port.in.AddCourseToCartUseCase;
+import com.gorogoro_cart.cart.application.port.in.ClearCartUseCase;
 import com.gorogoro_cart.cart.application.port.in.command.AddCourseToCartCommand;
+import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
+import com.gorogoro_cart.cart.common.exception.BusinessException;
+import com.gorogoro_cart.cart.common.exception.ErrorCode;
 import com.gorogoro_cart.cart.domain.model.entity.Cart;
 import com.gorogoro_cart.cart.domain.repository.CartRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class CartCommandService implements AddCourseToCartUseCase {
+public class CartCommandService implements AddCourseToCartUseCase, ClearCartUseCase {
     private final CartRepository cartRepository;
 
     @Override
@@ -23,6 +27,17 @@ public class CartCommandService implements AddCourseToCartUseCase {
                 .orElseGet(() -> Cart.create(userId));
 
         cart.addCourse(courseId);
+        cartRepository.save(cart);
+    }
+
+    @Override
+    public void clearCart(ClearCartCommand command) {
+        Long userId = command.userId();
+
+        Cart cart = cartRepository.findAllByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
+
+        cart.clear();
         cartRepository.save(cart);
     }
 }

--- a/src/main/java/com/gorogoro_cart/cart/application/service/CartCommandService.java
+++ b/src/main/java/com/gorogoro_cart/cart/application/service/CartCommandService.java
@@ -4,8 +4,6 @@ import com.gorogoro_cart.cart.application.port.in.AddCourseToCartUseCase;
 import com.gorogoro_cart.cart.application.port.in.ClearCartUseCase;
 import com.gorogoro_cart.cart.application.port.in.command.AddCourseToCartCommand;
 import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
-import com.gorogoro_cart.cart.common.exception.BusinessException;
-import com.gorogoro_cart.cart.common.exception.ErrorCode;
 import com.gorogoro_cart.cart.domain.model.entity.Cart;
 import com.gorogoro_cart.cart.domain.repository.CartRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,24 +18,20 @@ public class CartCommandService implements AddCourseToCartUseCase, ClearCartUseC
 
     @Override
     public void addCourse(AddCourseToCartCommand command) {
-        Long userId = command.userId();
-        Long courseId = command.courseId();
-
-        Cart cart = cartRepository.findAllByUserId(userId)
-                .orElseGet(() -> Cart.create(userId));
-
-        cart.addCourse(courseId);
+        Cart cart = getCart(command.userId());
+        cart.addCourse(command.courseId());
         cartRepository.save(cart);
     }
 
     @Override
     public void clearCart(ClearCartCommand command) {
-        Long userId = command.userId();
-
-        Cart cart = cartRepository.findAllByUserId(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.CART_NOT_FOUND));
-
+        Cart cart = getCart(command.userId());
         cart.clear();
         cartRepository.save(cart);
+    }
+
+    private Cart getCart(Long userId) {
+        return cartRepository.findAllByUserId(userId)
+                .orElseGet(() -> Cart.create(userId));
     }
 }

--- a/src/main/java/com/gorogoro_cart/cart/common/exception/BusinessException.java
+++ b/src/main/java/com/gorogoro_cart/cart/common/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package com.gorogoro_cart.cart.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/gorogoro_cart/cart/common/exception/ErrorCode.java
+++ b/src/main/java/com/gorogoro_cart/cart/common/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.gorogoro_cart.cart.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 404 NOT_FOUND
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 ID에 해당하는 장바구니를 찾을 수 없습니다."),
+
+    // 400 BAD REQUEST
+    COURSE_NOT_PURCHASABLE(HttpStatus.BAD_REQUEST, "현재 구매할 수 없는 강의입니다."),
+    ALREADY_ENROLLED_COURSE(HttpStatus.BAD_REQUEST, "이미 수강 중인 강의입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/gorogoro_cart/cart/common/exception/ErrorCode.java
+++ b/src/main/java/com/gorogoro_cart/cart/common/exception/ErrorCode.java
@@ -8,9 +8,6 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    // 404 NOT_FOUND
-    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 ID에 해당하는 장바구니를 찾을 수 없습니다."),
-
     // 400 BAD REQUEST
     COURSE_NOT_PURCHASABLE(HttpStatus.BAD_REQUEST, "현재 구매할 수 없는 강의입니다."),
     ALREADY_ENROLLED_COURSE(HttpStatus.BAD_REQUEST, "이미 수강 중인 강의입니다.");

--- a/src/main/java/com/gorogoro_cart/cart/domain/model/entity/Cart.java
+++ b/src/main/java/com/gorogoro_cart/cart/domain/model/entity/Cart.java
@@ -6,7 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class Cart {
 
     @Getter
@@ -28,10 +30,11 @@ public class Cart {
 
     public void addCourse(Long courseId) {
         Objects.requireNonNull(courseId, "courseId must not be null");
-        boolean exists = cartItems.stream()
+        boolean itemExists = cartItems.stream()
                 .anyMatch(item -> item.getCourseId().equals(courseId));
 
-        if (!exists) {
+        if (!itemExists) {
+            log.info("Cart_log : add duplicated course to user's cart.");
             cartItems.add(CartItem.of(courseId, Instant.now()));
         }
     }

--- a/src/main/java/com/gorogoro_cart/cart/domain/model/entity/Cart.java
+++ b/src/main/java/com/gorogoro_cart/cart/domain/model/entity/Cart.java
@@ -7,16 +7,15 @@ import java.util.List;
 import java.util.Objects;
 import lombok.Getter;
 
-@Getter
 public class Cart {
+
+    @Getter
     private final Long userId;
-    private final List<CartItem> cartItems = new ArrayList<>();
+    private final List<CartItem> cartItems;
 
     private Cart(Long userId, List<CartItem> cartItems) {
         this.userId = Objects.requireNonNull(userId, "userId must not be null.");
-        if (cartItems != null) {
-            this.cartItems.addAll(cartItems);
-        }
+        this.cartItems = new ArrayList<>(cartItems);
     }
 
     public static Cart create(Long userId) {

--- a/src/main/java/com/gorogoro_cart/cart/domain/repository/CartRepository.java
+++ b/src/main/java/com/gorogoro_cart/cart/domain/repository/CartRepository.java
@@ -1,10 +1,17 @@
 package com.gorogoro_cart.cart.domain.repository;
 
 import com.gorogoro_cart.cart.domain.model.entity.Cart;
+import com.gorogoro_cart.cart.domain.model.vo.CartItem;
+import java.util.List;
 import java.util.Optional;
 
 public interface CartRepository {
     Optional<Cart> findAllByUserId(Long userId);
 
-    void save(Cart cart);
+    /**
+     * - targetCart: 도메인에서 최종 상태로 완성된 Cart
+     * <p>
+     * - baselineItems: 저장 직전에 이미 알고 있는 기존 상태(서비스가 조회한 원본)
+     */
+    void save(Cart targetCart, List<CartItem> baselineItems);
 }

--- a/src/main/java/com/gorogoro_cart/cart/infrastructure/persistence/CartRepositoryAdapter.java
+++ b/src/main/java/com/gorogoro_cart/cart/infrastructure/persistence/CartRepositoryAdapter.java
@@ -7,6 +7,8 @@ import com.gorogoro_cart.cart.infrastructure.persistence.entity.CartItemJpaEntit
 import com.gorogoro_cart.cart.infrastructure.persistence.jpa.CartItemJpaRepository;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -27,21 +29,38 @@ public class CartRepositoryAdapter implements CartRepository {
                 .map(CartItemJpaEntity::toDomain)
                 .toList();
 
-        Cart cart = Cart.create(userId, items);
-        return Optional.of(cart);
+        return Optional.of(Cart.create(userId, items));
     }
 
     @Override
-    public void save(Cart cart) {
-        Long userId = cart.getUserId();
+    public void save(Cart targetCart, List<CartItem> baselineItems) {
+        Long userId = targetCart.getUserId();
 
-        itemJpaRepository.deleteAllByUserId(userId);
-        itemJpaRepository.flush();
+        Set<Long> baselineCourseIds = toCourseIdSet(baselineItems);
+        List<CartItem> targetItems = targetCart.getItems();
+        Set<Long> targetCourseIds = toCourseIdSet(targetItems);
 
-        List<CartItemJpaEntity> entities = cart.getCartItems().stream()
+        List<CartItemJpaEntity> entitiesToInsert = targetItems.stream()
+                .filter(item -> !baselineCourseIds.contains(item.getCourseId()))
                 .map(item -> CartItemJpaEntity.fromDomain(userId, item))
                 .toList();
 
-        itemJpaRepository.saveAll(entities);
+        List<Long> courseIdsToDelete = baselineCourseIds.stream()
+                .filter(courseId -> !targetCourseIds.contains(courseId))
+                .toList();
+
+        if (!courseIdsToDelete.isEmpty()) {
+            itemJpaRepository.deleteByUserIdAndCourseIdIn(userId, courseIdsToDelete);
+        }
+
+        if (!entitiesToInsert.isEmpty()) {
+            itemJpaRepository.saveAll(entitiesToInsert);
+        }
+    }
+
+    private static Set<Long> toCourseIdSet(List<CartItem> cartItems) {
+        return cartItems.stream()
+                .map(CartItem::getCourseId)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/com/gorogoro_cart/cart/infrastructure/persistence/CartRepositoryAdapter.java
+++ b/src/main/java/com/gorogoro_cart/cart/infrastructure/persistence/CartRepositoryAdapter.java
@@ -36,6 +36,7 @@ public class CartRepositoryAdapter implements CartRepository {
         Long userId = cart.getUserId();
 
         itemJpaRepository.deleteAllByUserId(userId);
+        itemJpaRepository.flush();
 
         List<CartItemJpaEntity> entities = cart.getCartItems().stream()
                 .map(item -> CartItemJpaEntity.fromDomain(userId, item))

--- a/src/main/java/com/gorogoro_cart/cart/infrastructure/persistence/jpa/CartItemJpaRepository.java
+++ b/src/main/java/com/gorogoro_cart/cart/infrastructure/persistence/jpa/CartItemJpaRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CartItemJpaRepository extends JpaRepository<CartItemJpaEntity, Long> {
     List<CartItemJpaEntity> findAllByUserId(Long userId);
 
-    void deleteAllByUserId(Long userId);
+    void deleteByUserIdAndCourseIdIn(Long userId, List<Long> courseIds);
 }

--- a/src/main/java/com/gorogoro_cart/cart/presentation/web/CartController.java
+++ b/src/main/java/com/gorogoro_cart/cart/presentation/web/CartController.java
@@ -4,7 +4,7 @@ import com.gorogoro_cart.cart.application.port.in.AddCourseToCartUseCase;
 import com.gorogoro_cart.cart.application.port.in.ClearCartUseCase;
 import com.gorogoro_cart.cart.application.port.in.command.AddCourseToCartCommand;
 import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
-import com.gorogoro_cart.cart.presentation.web.dto.CartRequest;
+import com.gorogoro_cart.cart.presentation.web.dto.AddCartRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,12 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class CartController {
     private final AddCourseToCartUseCase addCourseToCartUseCase;
     private final ClearCartUseCase clearCartUseCase;
-    
+
     // TODO : userId 유무 확인 필요 -> 임시로 PathVariable 사용
     @PostMapping("/{userId}")
     public ResponseEntity<Void> addCourseToCart(
             @PathVariable Long userId,
-            @Valid @RequestBody CartRequest request
+            @Valid @RequestBody AddCartRequest request
     ) {
         AddCourseToCartCommand command = new AddCourseToCartCommand(userId, request.courseId());
         addCourseToCartUseCase.addCourse(command);

--- a/src/main/java/com/gorogoro_cart/cart/presentation/web/CartController.java
+++ b/src/main/java/com/gorogoro_cart/cart/presentation/web/CartController.java
@@ -1,11 +1,14 @@
 package com.gorogoro_cart.cart.presentation.web;
 
 import com.gorogoro_cart.cart.application.port.in.AddCourseToCartUseCase;
+import com.gorogoro_cart.cart.application.port.in.ClearCartUseCase;
 import com.gorogoro_cart.cart.application.port.in.command.AddCourseToCartCommand;
+import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
 import com.gorogoro_cart.cart.presentation.web.dto.CartRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,7 +20,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CartController {
     private final AddCourseToCartUseCase addCourseToCartUseCase;
-
+    private final ClearCartUseCase clearCartUseCase;
+    
     // TODO : userId 유무 확인 필요 -> 임시로 PathVariable 사용
     @PostMapping("/{userId}")
     public ResponseEntity<Void> addCourseToCart(
@@ -27,5 +31,14 @@ public class CartController {
         AddCourseToCartCommand command = new AddCourseToCartCommand(userId, request.courseId());
         addCourseToCartUseCase.addCourse(command);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<Void> clearCart(
+            @PathVariable Long userId
+    ) {
+        ClearCartCommand command = new ClearCartCommand(userId);
+        clearCartUseCase.clearCart(command);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/gorogoro_cart/cart/presentation/web/dto/AddCartRequest.java
+++ b/src/main/java/com/gorogoro_cart/cart/presentation/web/dto/AddCartRequest.java
@@ -2,7 +2,7 @@ package com.gorogoro_cart.cart.presentation.web.dto;
 
 import jakarta.validation.constraints.NotNull;
 
-public record CartRequest(
+public record AddCartRequest(
         @NotNull(message = "course_id must not be null")
         Long courseId
 ) {

--- a/src/main/java/com/gorogoro_cart/cart/presentation/web/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/gorogoro_cart/cart/presentation/web/handler/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.gorogoro_cart.cart.presentation.web.handler;
 
+import com.gorogoro_cart.cart.common.exception.BusinessException;
+import com.gorogoro_cart.cart.common.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +13,20 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     /**
+     * 직접 정의한 비즈니스 예외를 처리합니다.
+     *
+     * @param e CustomException 객체
+     * @return ErrorCode에 정의된 HttpStatus와 메시지를 담은 ResponseEntity
+     */
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(new ErrorResponse(errorCode.name(), errorCode.getMessage()));
+    }
+
+    /**
      * 데이터베이스 무결성 제약 조건(예: Unique Key 중복) 위반 시 발생하는 예외를 처리합니다.
      *
      * @param e DataIntegrityViolationException 객체
@@ -20,5 +36,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<Void> handleDataIntegrityViolation(DataIntegrityViolationException e) {
         log.info("Duplicate item insert attempt caught and handled gracefully.");
         return ResponseEntity.ok().build();
+    }
+
+    private record ErrorResponse(String code, String message) {
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,9 +12,9 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        use_sql_comments: true
 
 logging:
   level:
-    org.hibernate.sql: DEBUG
-    org.hibernate.type.descriptor.sql.DdlType: trace
-
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: TRACE

--- a/src/test/java/com/gorogoro_cart/cart/application/service/CartCommandServiceTest.java
+++ b/src/test/java/com/gorogoro_cart/cart/application/service/CartCommandServiceTest.java
@@ -1,17 +1,17 @@
 package com.gorogoro_cart.cart.application.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static java.util.Optional.empty;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.gorogoro_cart.cart.application.port.in.command.AddCourseToCartCommand;
 import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
-import com.gorogoro_cart.cart.common.exception.BusinessException;
-import com.gorogoro_cart.cart.common.exception.ErrorCode;
 import com.gorogoro_cart.cart.domain.model.entity.Cart;
+import com.gorogoro_cart.cart.domain.model.vo.CartItem;
 import com.gorogoro_cart.cart.domain.repository.CartRepository;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,13 +37,22 @@ class CartCommandServiceTest {
         Long courseId = 10L;
         AddCourseToCartCommand command = new AddCourseToCartCommand(userId, courseId);
 
-        given(cartRepository.findAllByUserId(userId)).willReturn(Optional.empty());
+        given(cartRepository.findAllByUserId(userId)).willReturn(empty());
 
         // when
         cartCommandService.addCourse(command);
 
         // then
-        verify(cartRepository).save(any(Cart.class));
+        verify(cartRepository).save(
+                argThat(cart -> containsCourse(cart, courseId)),
+                eq(List.of())
+        );
+    }
+
+    private boolean containsCourse(Cart cart, Long courseId) {
+        return cart.getItems().stream()
+                .map(CartItem::getCourseId)
+                .anyMatch(id -> id.equals(courseId));
     }
 
     // TODO: 이미 수강 중인 강의이거나 판매 중이지 않은 강좌를 장바구니에 등록하려 한 경우 테스트 추가해야함.
@@ -54,31 +63,21 @@ class CartCommandServiceTest {
         // given
         Long userId = 1L;
         ClearCartCommand command = new ClearCartCommand(userId);
+
         Cart existingCart = Cart.create(userId);
         existingCart.addCourse(10L);
 
         given(cartRepository.findAllByUserId(userId)).willReturn(Optional.of(existingCart));
 
+        List<CartItem> baseline = existingCart.getItems();
+
         // when
         cartCommandService.clearCart(command);
 
         // then
-        assertThat(existingCart.getCartItems()).isEmpty();
-        verify(cartRepository).save(existingCart);
-    }
-
-    @Test
-    @DisplayName("장바구니가 존재하지 않을 경우 예외가 발생한다.")
-    void shouldThrowException_whenCartNotFound() {
-        // given
-        Long userId = 1L;
-        ClearCartCommand command = new ClearCartCommand(userId);
-
-        given(cartRepository.findAllByUserId(userId)).willReturn(Optional.empty());
-
-        // when // then
-        assertThatThrownBy(() -> cartCommandService.clearCart(command))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.CART_NOT_FOUND.getMessage());
+        verify(cartRepository).save(
+                argThat(cart -> cart.getItems().isEmpty()),
+                eq(baseline)
+        );
     }
 }

--- a/src/test/java/com/gorogoro_cart/cart/application/service/CartCommandServiceTest.java
+++ b/src/test/java/com/gorogoro_cart/cart/application/service/CartCommandServiceTest.java
@@ -1,0 +1,84 @@
+package com.gorogoro_cart.cart.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.gorogoro_cart.cart.application.port.in.command.AddCourseToCartCommand;
+import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
+import com.gorogoro_cart.cart.common.exception.BusinessException;
+import com.gorogoro_cart.cart.common.exception.ErrorCode;
+import com.gorogoro_cart.cart.domain.model.entity.Cart;
+import com.gorogoro_cart.cart.domain.repository.CartRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CartCommandServiceTest {
+
+    @InjectMocks
+    private CartCommandService cartCommandService;
+
+    @Mock
+    private CartRepository cartRepository;
+
+    @Test
+    @DisplayName("장바구니에 강좌를 추가할 수 있다.")
+    void shouldAddCourseToCart() {
+        // given
+        Long userId = 1L;
+        Long courseId = 10L;
+        AddCourseToCartCommand command = new AddCourseToCartCommand(userId, courseId);
+
+        given(cartRepository.findAllByUserId(userId)).willReturn(Optional.empty());
+
+        // when
+        cartCommandService.addCourse(command);
+
+        // then
+        verify(cartRepository).save(any(Cart.class));
+    }
+
+    // TODO: 이미 수강 중인 강의이거나 판매 중이지 않은 강좌를 장바구니에 등록하려 한 경우 테스트 추가해야함.
+
+    @Test
+    @DisplayName("장바구니 전체 비우기가 가능하다.")
+    void shouldClearCart() {
+        // given
+        Long userId = 1L;
+        ClearCartCommand command = new ClearCartCommand(userId);
+        Cart existingCart = Cart.create(userId);
+        existingCart.addCourse(10L);
+
+        given(cartRepository.findAllByUserId(userId)).willReturn(Optional.of(existingCart));
+
+        // when
+        cartCommandService.clearCart(command);
+
+        // then
+        assertThat(existingCart.getCartItems()).isEmpty();
+        verify(cartRepository).save(existingCart);
+    }
+
+    @Test
+    @DisplayName("장바구니가 존재하지 않을 경우 예외가 발생한다.")
+    void shouldThrowException_whenCartNotFound() {
+        // given
+        Long userId = 1L;
+        ClearCartCommand command = new ClearCartCommand(userId);
+
+        given(cartRepository.findAllByUserId(userId)).willReturn(Optional.empty());
+
+        // when // then
+        assertThatThrownBy(() -> cartCommandService.clearCart(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.CART_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## Issue
- #10

## 변경 사항

- 장바구니 저장을 기존의 deleteAll → flush → insertAll 방식에서, baseline(기존 아이템)과 target(도메인에서 변경된 최종 상태)을 비교해 변경분만 반영하는 델타 저장 방식으로 전환했습니다. 

- 이를 통해 1건 변경에도 전체 삭제/삽입이 발생하던 비효율을 제거하고, addedAt의 의미를 보존하면서도 Cart Aggregate 중심의 도메인 행위를 유지할 수 있도록 했습니다. 

- 서비스는 baseline을 로드해 targetCart를 구성하고, 어댑터는 비교 결과에 따라 필요한 insert/delete만 수행하도록 책임을 분리했습니다.