### PR TITLE
장바구니 아이템 존재 검증 & 오류 처리 & custom code 추가

### DIFF
--- a/src/main/java/com/gorogoro_cart/cart/application/service/CartCommandService.java
+++ b/src/main/java/com/gorogoro_cart/cart/application/service/CartCommandService.java
@@ -25,7 +25,7 @@ public class CartCommandService implements AddCourseToCartUseCase, ClearCartUseC
 
     @Override
     public void addCourse(AddCourseToCartCommand command) {
-        validateAlreadyExist(command);
+        requireCartItemPresence(command.userId(), command.courseId(), false);
         CartItem newItem = CartItem.of(command.userId(), command.courseId(), Instant.now());
         cartRepository.save(newItem);
     }
@@ -37,11 +37,16 @@ public class CartCommandService implements AddCourseToCartUseCase, ClearCartUseC
 
     @Override
     public void removeCartItem(RemoveCartItemCommand command) {
+        requireCartItemPresence(command.userId(), command.courseId(), true);
         cartRepository.deleteByUserIdAndCourseId(command.userId(), command.courseId());
     }
 
-    private void validateAlreadyExist(AddCourseToCartCommand command) {
-        if (cartRepository.existsByUserIdAndCourseId(command.userId(), command.courseId())) {
+    private void requireCartItemPresence(Long userId, Long courseId, boolean shouldExist) {
+        boolean exists = cartRepository.existsByUserIdAndCourseId(userId, courseId);
+        if (shouldExist && !exists) {
+            throw new BusinessException(ErrorCode.CART_ITEM_NOT_FOUND);
+        }
+        if (!shouldExist && exists) {
             throw new BusinessException(ErrorCode.CART_ITEM_ALREADY_EXISTS);
         }
     }

--- a/src/main/java/com/gorogoro_cart/cart/common/exception/ErrorCode.java
+++ b/src/main/java/com/gorogoro_cart/cart/common/exception/ErrorCode.java
@@ -9,20 +9,24 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // 400 BAD_REQUEST: 잘못된 요청
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
-    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "필수 요청 파라미터가 누락되었습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다.", "CRT-1000"),
+    MISSING_REQUEST_PARAMETER(HttpStatus.BAD_REQUEST, "필수 요청 파라미터가 누락되었습니다.", "CRT-1001"),
+
+    // 404 NOT FOUND: 존재하지 않음
+    CART_ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "장바구니에 해당 강좌가 없습니다.", "CRT-4000"),
 
     // 409 CONFLICT: 요청이 서버의 현재 상태와 충돌
-    COURSE_NOT_PURCHASABLE(HttpStatus.CONFLICT, "현재 구매할 수 없는 강의입니다."),
-    ALREADY_ENROLLED_COURSE(HttpStatus.CONFLICT, "이미 수강 중인 강의입니다."),
-    CART_ITEM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 장바구니에 담긴 강의입니다."),
+    COURSE_NOT_PURCHASABLE(HttpStatus.CONFLICT, "현재 구매할 수 없는 강의입니다.", "CRT-2000"),
+    ALREADY_ENROLLED_COURSE(HttpStatus.CONFLICT, "이미 수강 중인 강의입니다.", "CRT-2001"),
+    CART_ITEM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 장바구니에 담긴 강의입니다.", "CRT-2002"),
 
-    // 500 INTERNAL_SERVER_ERROR: 서버 내부 오류,
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 예상치 못한 오류가 발생했습니다."),
+    // 500 INTERNAL_SERVER_ERROR: 서버 내부 오류
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 예상치 못한 오류가 발생했습니다.", "CRT-5000"),
 
     // 503 SERVICE_UNAVAILABLE: 외부 서비스 불가
-    COURSE_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "강의 서비스가 응답하지 않습니다.");
+    COURSE_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "강의 서비스가 응답하지 않습니다.", "CRT-5001");
 
     private final HttpStatus status;
     private final String message;
+    private final String code;
 }

--- a/src/main/java/com/gorogoro_cart/cart/presentation/web/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/gorogoro_cart/cart/presentation/web/handler/GlobalExceptionHandler.java
@@ -33,7 +33,7 @@ public class GlobalExceptionHandler {
             MissingServletRequestParameterException e) {
         final ErrorCode errorCode = ErrorCode.MISSING_REQUEST_PARAMETER;
         final String message = String.format("필수 파라미터 '%s'(이)가 누락되었습니다.", e.getParameterName());
-        final ErrorResponse response = new ErrorResponse(errorCode.name(), message);
+        final ErrorResponse response = new ErrorResponse(errorCode.getCode(), message);
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
@@ -46,19 +46,21 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(BusinessException e) {
         final ErrorCode errorCode = e.getErrorCode();
-        return new ResponseEntity<>(new ErrorResponse(errorCode.name(), errorCode.getMessage()), errorCode.getStatus());
+        return new ResponseEntity<>(new ErrorResponse(errorCode.getCode(), errorCode.getMessage()),
+                errorCode.getStatus());
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
         final ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
         log.error("Unhandled exception occurred: {}", e.getMessage(), e);
-        return new ResponseEntity<>(new ErrorResponse(errorCode.name(), errorCode.getMessage()), errorCode.getStatus());
+        return new ResponseEntity<>(new ErrorResponse(errorCode.getCode(), errorCode.getMessage()),
+                errorCode.getStatus());
     }
 
     private record ErrorResponse(String code, String message) {
         public static ErrorResponse of(ErrorCode code, BindingResult bindingResult) {
-            return new ErrorResponse(code.name(), createErrorMessage(bindingResult));
+            return new ErrorResponse(code.getCode(), createErrorMessage(bindingResult));
         }
 
         private static String createErrorMessage(BindingResult bindingResult) {

--- a/src/test/java/com/gorogoro_cart/cart/application/service/CartCommandServiceTest.java
+++ b/src/test/java/com/gorogoro_cart/cart/application/service/CartCommandServiceTest.java
@@ -1,5 +1,6 @@
 package com.gorogoro_cart.cart.application.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -7,6 +8,8 @@ import static org.mockito.Mockito.verify;
 import com.gorogoro_cart.cart.application.port.in.command.AddCourseToCartCommand;
 import com.gorogoro_cart.cart.application.port.in.command.ClearCartCommand;
 import com.gorogoro_cart.cart.application.port.in.command.RemoveCartItemCommand;
+import com.gorogoro_cart.cart.common.exception.BusinessException;
+import com.gorogoro_cart.cart.common.exception.ErrorCode;
 import com.gorogoro_cart.cart.domain.model.CartItem;
 import com.gorogoro_cart.cart.domain.repository.CartRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -65,11 +68,27 @@ class CartCommandServiceTest {
         Long userId = 1L;
         Long courseId = 10L;
         RemoveCartItemCommand command = new RemoveCartItemCommand(userId, courseId);
+        given(cartRepository.existsByUserIdAndCourseId(userId, courseId)).willReturn(true);
 
         // when
         cartCommandService.removeCartItem(command);
 
         // then
         verify(cartRepository).deleteByUserIdAndCourseId(userId, courseId);
+    }
+
+    @Test
+    @DisplayName("장바구니에 없는 아이템 삭제 시 예외가 발생한다.")
+    void shouldThrowWhenRemovingNonExistingItem() {
+        // given
+        Long userId = 3L;
+        Long courseId = 30L;
+        RemoveCartItemCommand command = new RemoveCartItemCommand(userId, courseId);
+        given(cartRepository.existsByUserIdAndCourseId(userId, courseId)).willReturn(false);
+
+        // when // then
+        assertThatThrownBy(() -> cartCommandService.removeCartItem(command))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining(ErrorCode.CART_ITEM_NOT_FOUND.getMessage());
     }
 }


### PR DESCRIPTION
## Custom Code 대역
  - `1000~1999`: 요청/유효성(400)
  - `2000~2999`: 비즈니스 충돌/불가(409)
  - `3000~3999`: 인증/권한(401/403) 
  - `4000~4999`: 리소스 상태(404/410 등)
  - `5000~5999`: 서버/외부(5xx)

> 대역을 정한 이유는 순차적으로 번호를 할당했을 경우 계속 추가되는 예외에 맞춰 번호를 재할당 해줘야하는 불편함을 해소하고자 결정해봤습니다.